### PR TITLE
В базовую мутацию была добавлена автоматическая обработка ошибки ValidationError

### DIFF
--- a/devind_helpers/schema/mutations.py
+++ b/devind_helpers/schema/mutations.py
@@ -1,5 +1,11 @@
+"""Вспомогательные мутации."""
+from typing import Any, Coroutine, Union
+
 import graphene
+from django.core.exceptions import ValidationError
 from graphene import relay
+from graphene.utils.thenables import Promise, maybe_thenable
+from graphql import ResolveInfo
 
 from devind_helpers.schema.types import ErrorFieldType
 
@@ -20,11 +26,29 @@ class BaseMutation(relay.ClientIDMutation):
         if self.errors is None:
             self.errors = []
 
+    @classmethod
+    def mutate(cls, root: Any, info: ResolveInfo, input: dict) -> Union[Coroutine, Promise]:
+        """Переопределение базового метода для обработки ошибок."""
+        def on_resolve(payload):
+            try:
+                payload.client_mutation_id = input.get('client_mutation_id')
+            except Exception:
+                raise Exception(
+                    f'Cannot set client_mutation_id in the payload object {repr(payload)}'
+                )
+            return payload
+
+        try:
+            return super().mutate(root, info, input)
+        except ValidationError as error:
+            return maybe_thenable(
+                cls(success=False, errors=ErrorFieldType.from_messages_dict(error.message_dict)),
+                on_resolve
+            )
+
     def add_error(self, field: str, messages: list[str]) -> None:
         """Добавление ошибки.
-
         :param field: поле ошибки
         :param messages: сообщения ошибки
         """
-
         self.errors.append(ErrorFieldType(field=field, messages=messages))

--- a/devind_helpers/validator/validators.py
+++ b/devind_helpers/validator/validators.py
@@ -3,7 +3,7 @@ import re
 import socket
 from copy import deepcopy
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class RuleNotFoundError(Exception):

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,16 @@
+"""Django's command-line utility for administrative tasks."""
+
+import os
+import sys
+
+from django.core.management import execute_from_command_line
+
+
+def main() -> None:
+    """Run administrative tasks."""
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.settings')
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Framework :: Django"
 ]
 
-
 [tool.poetry.dependencies]
 python = "^3.9"
 redis = "^4.1.4"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from .schema import BaseMutationTestCase, ErrorFieldTypeTestCase

--- a/tests/schema/__init__.py
+++ b/tests/schema/__init__.py
@@ -1,0 +1,2 @@
+from .mutations import BaseMutationTestCase
+from .types import ErrorFieldTypeTestCase

--- a/tests/schema/mutations.py
+++ b/tests/schema/mutations.py
@@ -1,0 +1,82 @@
+"""Тесты вспомогательных мутаций."""
+from collections import OrderedDict
+from typing import Any
+
+import graphene
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from graphql import ResolveInfo
+
+from devind_helpers.schema import BaseMutation
+
+
+class TestMutation(BaseMutation):
+    """Мутация для тестирования."""
+
+    class Input:
+        i = graphene.String(required=True)
+
+    digit = graphene.Int()
+
+    @staticmethod
+    def mutate_and_get_payload(root: Any, info: ResolveInfo, i: str):
+        if i.isdigit():
+            return TestMutation(digit=int(i))
+        raise ValidationError(message={
+            'i': ['Ожидалась строка с числом']
+        })
+
+
+class TestMutations(graphene.ObjectType):
+    """Мутации для тестирования."""
+
+    test_mutation = TestMutation.Field(required=True)
+
+
+class BaseMutationTestCase(TestCase):
+    """Тесты класса `BaseMutation`."""
+
+    def setUp(self) -> None:
+        """Создание данных для тестирования."""
+        self.schema = graphene.Schema(mutation=TestMutations)
+
+    def test_mutate(self) -> None:
+        """Тестирование метода `mutate` без ошибок."""
+        result = self.schema.execute(self._create_test_mutation_query('5'))
+        expected_data = OrderedDict()
+        expected_data['testMutation'] = {
+            'digit': 5,
+            'success': True,
+            'errors': []
+        }
+        self.assertEqual(expected_data, result.data)
+
+    def test_mutate_validation_error(self) -> None:
+        """Тестирование метода `mutate` с ошибкой `ValidationError`."""
+        result = self.schema.execute(self._create_test_mutation_query('x'))
+        expected_data = OrderedDict()
+        expected_data['testMutation'] = {
+            'digit': None,
+            'success': False,
+            'errors': [{
+                'field': 'i',
+                'messages': ['Ожидалась строка с числом']
+            }]
+        }
+        self.assertEqual(expected_data, result.data)
+
+    @staticmethod
+    def _create_test_mutation_query(i: str):
+        """Создание запроса для тестовой мутации."""
+        return f"""
+            mutation {{
+                testMutation(input: {{ i: "{i}" }}) {{
+                    digit
+                    success
+                    errors {{
+                        field
+                        messages
+                    }}
+                }}
+            }}
+        """

--- a/tests/schema/types.py
+++ b/tests/schema/types.py
@@ -1,0 +1,40 @@
+"""Тесты вспомогательных типов."""
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from devind_helpers.schema.types import ErrorFieldType
+from devind_helpers.validator import Validator
+
+
+class ErrorFieldTypeTestCase(TestCase):
+    """Тесты класса `ErrorFieldType`."""
+
+    class TestValidator(Validator):
+        """Тестовый валидатор."""
+
+        field = 'required'
+
+        message = {
+            'field': {
+                'required': 'message'
+            }
+        }
+
+    def test_from_validator(self) -> None:
+        """Тестирование метода `from_validator`."""
+        validator = ErrorFieldTypeTestCase.TestValidator({})
+        validator.validate()
+        self.assertEqual(
+            [ErrorFieldType(field='field', messages=['message'])],
+            ErrorFieldType.from_validator(validator.get_message())
+        )
+
+    def test_from_messages_dict(self) -> None:
+        """Тестирование метода `from_messages_dict`."""
+        validation_error = ValidationError(message={
+            'field': ['message1', 'message2']
+        })
+        self.assertEqual(
+            [ErrorFieldType(field='field', messages=['message1', 'message2'])],
+            ErrorFieldType.from_messages_dict(validation_error.message_dict)
+        )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,22 @@
+"""Настройки Django для тестов."""
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'sqlite3.db',
+    }
+}
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+INSTALLED_APPS = (
+    'tests',
+)
+
+MIDDLEWARE = []
+
+USE_TZ = True
+
+TIME_ZONE = 'UTC'
+
+DOCUMENTS_DIR = ''


### PR DESCRIPTION
Closes #27.

Что-то такое мы придумали с Андреем еще давно. Мне кажется такой подход с киданием ValidationError в сервисах и автоматической обработкой оптимальным по следующим причинам:
- Он используется в strawberry и не нужно будет ничего менять, если будем переходить;
- Подход на автоматической обработке исключений уже используется в разрешениях, только там полагаемся на ошибку GraphQL, а тут на отдельный тип ErrorFieldType;
- Прокидывать errors через tuple результата не удобно, особенно если сервисы вызывают друг друга;
- Возврат ErrorFieldType из сервисов создает зависимость сервисов на схему, чего не должно быть.

Последний пункт меня смущает больше всего, т.к. подтачивает архитектуру. Если оставлять старое решение, то я бы заменил ErrorFieldType в сервисах на другой класс или словарь и уже в мутации кастовал бы к ErrorFieldType.

Из минусов я вижу:
- В некоторой степени теряется очевидность обработки ошибок, т.к. исключения сомнительная концепция в целом;
- Если нужно положить дополнительные данные в ошибку, например как missing_divisions в скрине ниже, то исключение придется обрабатывать руками. Данную проблему можно решить через автоматическую обработку kwargs у ValidationError, но тогда очевидность теряется еще сильнее.

![image](https://user-images.githubusercontent.com/66582102/195242763-20d6e4ec-abea-4085-a5bd-495771441410.png)

Также есть такой вариант, что-то похожее используется в Rust, где исключения отсутствуют, как концепция:

![image](https://user-images.githubusercontent.com/66582102/195244998-152a4ab0-29de-40ef-bed0-59b561207d50.png)
![image](https://user-images.githubusercontent.com/66582102/195245120-2c1b71b9-52f3-4647-b0bb-a2410ee337f5.png)

